### PR TITLE
Fix minor bug with generics + traits

### DIFF
--- a/doku-derive/src/expand/utils.rs
+++ b/doku-derive/src/expand/utils.rs
@@ -10,8 +10,9 @@ pub fn new_generics_with_where_clause(
             syn::GenericParam::Const(_) => (),
             syn::GenericParam::Lifetime(_) => (),
             syn::GenericParam::Type(t) => {
+                let t = &t.ident;
                 let predicate: syn::WherePredicate =
-                    syn::parse2(quote! { #t: ::doku::Document }).unwrap();
+                    syn::parse2(quote! { #t: ::doku::Document })?;
                 where_clause.predicates.push(predicate);
             }
         };

--- a/doku/tests/printers/struct/mod.rs
+++ b/doku/tests/printers/struct/mod.rs
@@ -5,6 +5,7 @@ mod with_examples;
 mod with_flattened_field;
 mod with_flattened_transparent_field;
 mod with_generics;
+mod with_generics_and_trait;
 mod with_literal_examples;
 mod with_multiline_comment;
 mod with_optional_field;

--- a/doku/tests/printers/struct/with_generics_and_trait/mod.rs
+++ b/doku/tests/printers/struct/with_generics_and_trait/mod.rs
@@ -1,0 +1,14 @@
+use std::fmt::Display;
+
+use crate::prelude::*;
+
+trait Trait {}
+
+#[derive(Document)]
+struct Generic<D: Display> {
+    inner: D,
+}
+
+printer_test! {
+    "output.json" => to_json(Generic<String>),
+}

--- a/doku/tests/printers/struct/with_generics_and_trait/output.json
+++ b/doku/tests/printers/struct/with_generics_and_trait/output.json
@@ -1,0 +1,3 @@
+{
+  "inner": "string"
+}


### PR DESCRIPTION
The recently implemented generic parser was not working properly when any trait bounds were specified at the trait definition (instead of using a `where` clause), so like this:

```
struct Something<T: Trait> {
  /* ... */
}
```
This commit fixes the aforementioned bug.