### PR TITLE
Collect aliases using the derive macro

### DIFF
--- a/doku-derive/src/attrs/serde/field.rs
+++ b/doku-derive/src/attrs/serde/field.rs
@@ -51,11 +51,12 @@ impl SerdeField {
             .map(|attrs| attrs.fold(Self::default(), Self::merge))
     }
 
-    pub fn merge(self, other: Self) -> Self {
+    pub fn merge(mut self, mut other: Self) -> Self {
+        self.alias.append(&mut other.alias);
         Self {
-            alias: Default::default(), // it's a no-op for us
-            default: None,             // it's a no-op for us
-            deserialize_with: None,    // it's a no-op for us
+            alias: self.alias,
+            default: None,          // it's a no-op for us
+            deserialize_with: None, // it's a no-op for us
             flatten: other.flatten.or(self.flatten),
             rename: other.rename.or(self.rename),
             serialize_with: None, // it's a no-op for us

--- a/doku-derive/src/attrs/serde/variant.rs
+++ b/doku-derive/src/attrs/serde/variant.rs
@@ -48,11 +48,13 @@ impl SerdeVariant {
             .map(|attrs| attrs.fold(Self::default(), Self::merge))
     }
 
-    pub fn merge(self, other: Self) -> Self {
+    pub fn merge(self, mut other: Self) -> Self {
+        let mut alias = self.alias;
+        alias.append(&mut other.alias);
         Self {
-            alias: Default::default(), // it's a no-op for us
-            deserialize_with: None,    // it's a no-op for us
-            other: None,               // it's a no-op for us
+            alias,
+            deserialize_with: None, // it's a no-op for us
+            other: None,            // it's a no-op for us
             rename: other.rename.or(self.rename),
             rename_all: other.rename_all.or(self.rename_all),
             serialize_with: None, // it's a no-op for us

--- a/doku-derive/src/expand/expand_field.rs
+++ b/doku-derive/src/expand/expand_field.rs
@@ -21,6 +21,7 @@ pub fn expand_field(
         metas: quote! { Default::default() },
         comment: quote! { None },
         example: quote! { None },
+        aliases: quote! { &[] },
         tag: quote! { None },
         serializable: true,
         deserializable: true,
@@ -38,6 +39,7 @@ struct Field {
     name: TokenStream2,
     ty: TokenStream2,
     comment: TokenStream2,
+    aliases: TokenStream2,
     example: TokenStream2,
     metas: TokenStream2,
     tag: TokenStream2,
@@ -55,7 +57,7 @@ impl Field {
 
     fn add_serde_attrs(&mut self, attrs: &[syn::Attribute]) -> Result<()> {
         let attrs::SerdeField {
-            alias: _,
+            alias,
             default: _,
             deserialize_with: _,
             flatten,
@@ -70,6 +72,10 @@ impl Field {
 
         if let Some(val) = flatten {
             self.flattened = val;
+        }
+
+        if !alias.is_empty() {
+            self.aliases = quote! { &[#(#alias,)*] };
         }
 
         if let Some(val) = rename {
@@ -162,6 +168,7 @@ impl Field {
             serializable,
             deserializable,
             flattened,
+            aliases,
         } = self;
 
         if serializable || deserializable {
@@ -180,6 +187,8 @@ impl Field {
                     },
 
                     flattened: #flattened,
+
+                    aliases: #aliases,
                 }
             };
 

--- a/doku/examples/aliases.rs
+++ b/doku/examples/aliases.rs
@@ -1,0 +1,32 @@
+#![allow(dead_code)]
+
+use doku::{Document, Fields, TypeKind};
+use serde::Deserialize;
+
+#[derive(Document, Deserialize)]
+struct OurStruct {
+    #[serde(alias = "foo")]
+    foos: Vec<String>,
+
+    #[serde(alias = "bar")]
+    #[serde(alias = "baz")]
+    bars: Vec<String>,
+}
+
+fn main() {
+    if let doku::Type {
+        kind:
+            TypeKind::Struct {
+                fields: Fields::Named { fields },
+                ..
+            },
+        ..
+    } = OurStruct::ty()
+    {
+        for (name, field) in fields {
+            println!("Aliases for {}: {:?}", name, field.aliases);
+        }
+    } else {
+        unreachable!();
+    }
+}

--- a/doku/examples/custom-impl.rs
+++ b/doku/examples/custom-impl.rs
@@ -21,6 +21,7 @@ impl doku::Document for Paper {
                     doku::Field {
                         ty: String::ty(),
                         flattened: false,
+                        aliases: &[],
                     },
                 )],
             },

--- a/doku/src/lib.rs
+++ b/doku/src/lib.rs
@@ -273,6 +273,7 @@
 //!                 ..String::ty()
 //!             },
 //!             flattened: false,
+//!             aliases: &[],
 //!         };
 //!
 //!         doku::Type::from(doku::TypeKind::Struct {

--- a/doku/src/objects/document/std.rs
+++ b/doku/src/objects/document/std.rs
@@ -90,6 +90,7 @@ fn duration() -> Type {
                             ..u64::ty()
                         },
                         flattened: false,
+                        aliases: &[],
                     },
                 ),
                 (
@@ -100,6 +101,7 @@ fn duration() -> Type {
                             ..u32::ty()
                         },
                         flattened: false,
+                        aliases: &[],
                     },
                 ),
             ],

--- a/doku/src/objects/field.rs
+++ b/doku/src/objects/field.rs
@@ -7,6 +7,9 @@ pub struct Field {
 
     /// Whether this field should get flattened (i.e. `#[serde(flatten)]`)
     pub flattened: bool,
+
+    /// The serde aliases for this field
+    pub aliases: &'static [&'static str],
 }
 
 impl From<Type> for Field {
@@ -14,6 +17,7 @@ impl From<Type> for Field {
         Self {
             ty,
             flattened: false,
+            aliases: &[],
         }
     }
 }

--- a/doku/src/objects/variant.rs
+++ b/doku/src/objects/variant.rs
@@ -15,4 +15,5 @@ pub struct Variant {
     pub serializable: bool,
     pub deserializable: bool,
     pub fields: Fields,
+    pub aliases: &'static [&'static str],
 }

--- a/doku/tests/attributes.rs
+++ b/doku/tests/attributes.rs
@@ -1,0 +1,42 @@
+use doku::{Document, Fields, TypeKind};
+
+#[test]
+fn serde_aliases_are_collected_by_document() {
+    #[derive(serde::Deserialize, Document)]
+    #[allow(dead_code)]
+    struct Thing {
+        #[serde(alias = "foos")]
+        foo: String,
+
+        #[serde(alias = "bat")]
+        #[serde(alias = "baz")]
+        bar: i32,
+    }
+
+    if let doku::Type {
+        kind:
+            TypeKind::Struct {
+                fields: Fields::Named { fields },
+                ..
+            },
+        ..
+    } = Thing::ty()
+    {
+        let foo_aliases = fields
+            .iter()
+            .find(|(name, _)| *name == "foo")
+            .unwrap()
+            .1
+            .aliases;
+        let bar_aliases = fields
+            .iter()
+            .find(|(name, _)| *name == "bar")
+            .unwrap()
+            .1
+            .aliases;
+        assert_eq!(foo_aliases, ["foos"]);
+        assert_eq!(bar_aliases, ["bat", "baz"]);
+    } else {
+        unreachable!();
+    }
+}


### PR DESCRIPTION
It's often useful to be able to document aliases for configuration fields, but doku currently ignores all of this information from serde. This PR adds support to collect this information so it can be accessed by the user of doku. It doesn't modify the generated toml/json documentation, it simply adds an `aliases` field to `doku::Field`

I couldn't find any prior art on tests which interact with the generated code other than printers or checking for compilation errors, so I added an integration test in a new file.